### PR TITLE
chore: add missing bin field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   },
   "author": "RudderStack",
   "license": "MIT",
-  "main": "./src/cli/index.js",
   "type": "module",
+  "main": "./src/cli/index.js",
+  "bin": {
+    "rudder-typer": "./src/cli/index.js"
+  },
   "scripts": {
     "setup": "npm ci",
     "init": "npm run cli init",


### PR DESCRIPTION
I've added the missing `bin` field in the package.json that was accidentally removed.

# Thank You for Contributing to RudderTyper!

We sincerely appreciate the time and effort you invest in helping to improve RudderTyper. To make the most of your contribution, we kindly ask that you document your Pull Request thoroughly.

Please note that if the information provided is insufficient, or if the Pull Request does not align with our roadmap, we may need to respectfully thank you for your effort and close the issue.

## Description 📝

> Please provide a detailed description of the changes you’ve made in this section. Clearly explain what has been modified, added, or removed, and how it impacts the overall project.

## Respect Earns Respect 👏

We ask that you adhere to our [Code of Conduct](CODE_OF_CONDUCT.md). In summary:

- Use welcoming and inclusive language.
- Respect differing viewpoints and experiences.
- Accept constructive criticism gracefully.
- Focus on what is best for the community.
- Show empathy toward other community members.
