### PR TITLE
chore: move typescript to prod dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,11 @@
         "prettier": "3.3.3",
         "react": "18.3.1",
         "sort-keys": "5.0.0",
+        "typescript": "5.5.4",
         "yargs": "17.7.2"
+      },
+      "bin": {
+        "rudder-typer": "src/cli/index.js"
       },
       "devDependencies": {
         "@types/jest": "29.5.12",
@@ -54,8 +58,7 @@
         "ts-jest": "29.2.4",
         "ts-node": "10.9.2",
         "tsconfig-paths": "4.2.0",
-        "tsx": "4.17.0",
-        "typescript": "5.5.4"
+        "tsx": "4.17.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -8920,7 +8923,6 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "ts-jest": "29.2.4",
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
-    "tsx": "4.17.0",
-    "typescript": "5.5.4"
+    "tsx": "4.17.0"
   },
   "dependencies": {
     "figures": "6.1.0",
@@ -79,7 +78,8 @@
     "prettier": "3.3.3",
     "react": "18.3.1",
     "sort-keys": "5.0.0",
-    "yargs": "17.7.2"
+    "yargs": "17.7.2",
+    "typescript": "5.5.4"
   },
   "files": [
     "src",


### PR DESCRIPTION
I've moved `typescript` to prod dependencies as it is used by the generator modules.

# Thank You for Contributing to RudderTyper!

We sincerely appreciate the time and effort you invest in helping to improve RudderTyper. To make the most of your contribution, we kindly ask that you document your Pull Request thoroughly.

Please note that if the information provided is insufficient, or if the Pull Request does not align with our roadmap, we may need to respectfully thank you for your effort and close the issue.

## Description 📝

> Please provide a detailed description of the changes you’ve made in this section. Clearly explain what has been modified, added, or removed, and how it impacts the overall project.

## Respect Earns Respect 👏

We ask that you adhere to our [Code of Conduct](CODE_OF_CONDUCT.md). In summary:

- Use welcoming and inclusive language.
- Respect differing viewpoints and experiences.
- Accept constructive criticism gracefully.
- Focus on what is best for the community.
- Show empathy toward other community members.
