### PR TITLE
feat: add named enum for javascript

### DIFF
--- a/src/generators/javascript/templates/index.hbs
+++ b/src/generators/javascript/templates/index.hbs
@@ -61,6 +61,14 @@ export interface Schema {
 }
 
 {{#each objects}}
+{{#each properties}}
+{{#if hasEnum}}
+export enum {{enumName}} {
+	{{enumValues}}
+}
+{{/if}}
+{{/each}}
+
 {{#if description}}
 /**
  * {{description}}
@@ -73,11 +81,11 @@ export interface {{name}} {{#unless ../isBrowser}} extends ApiObject {{/unless}}
 	 * {{description}}
 	 */
 	{{/if}}
-	'{{name}}'{{#unless isRequired}}?{{/unless}}: {{type}}
+	'{{name}}'{{#unless isRequired}}?{{/unless}}: {{#if hasEnum}}{{enumName}}{{else}}{{type}}{{/if}}
 	{{/each}}
 }
-{{/each}}
 
+{{/each}}
 export type ViolationHandler = (
 	message: {{#if isBrowser}}Record<string, any>{{else}}TrackMessage<Record<string, any>>{{/if}},
 	{{!-- Swap the type definitions here so we don't want depend on ajv in production just for this type definition. --}}
@@ -245,7 +253,7 @@ function withRudderTyperContext{{#unless isBrowser}}<P, T extends TrackMessage<P
 	{{!-- Note: this uses whitespace control to "escape" the outer curly braces. --}}
 	{{!-- Note: The backticks enable JSDoc to parse names with spaces (without resorting to square brackets). --}}
 	{{!-- Temporary removed backticks around required names below because of typescript compiler + JSDoc error. Will investigate. --}}
- * @property { {{~type~}} } {{#if isRequired}}{{name}}{{else}}[{{name}}]{{/if}} - {{description}}
+ * @property {{#if hasEnum}}{ {{~enumName~}} }{{else}}{ {{~type~}} }{{/if}} {{#if isRequired}}{{name}}{{else}}[{{name}}]{{/if}} - {{description}}
  {{/each}}
  */
 {{/each}}


### PR DESCRIPTION
# Thank You for Contributing to RudderTyper!

We sincerely appreciate the time and effort you invest in helping to improve RudderTyper. To make the most of your contribution, we kindly ask that you document your Pull Request thoroughly.

Please note that if the information provided is insufficient, or if the Pull Request does not align with our roadmap, we may need to respectfully thank you for your effort and close the issue.

## Description 📝

> add named enum for javascript
we have enum for `string` and `number` and we append `S_` for `string` and `N_`for `number`
eg:
export enum Affiliation {
  S_PROD = 'prod',
  S_DEV = 'dev',
  S_1 = '1',
  S_22 = '22',
}
export enum Age {
  S_PROD = 'prod',
  N_10 = 10,
  N_20 = 20,
}
export enum Width {
  N_10 = 10,
  N_20 = 20,
  S_ABC = 'abc',
}

export interface CartShared {
  affiliation?: Affiliation;
  age?: Age;
  age2?: number[];
  bool?: boolean;
  nulll?: any | null;
  cartSharedPropObject2?: Record<string, any>;
  width?: Width;
}

## Respect Earns Respect 👏

We ask that you adhere to our [Code of Conduct](CODE_OF_CONDUCT.md). In summary:

- Use welcoming and inclusive language.
- Respect differing viewpoints and experiences.
- Accept constructive criticism gracefully.
- Focus on what is best for the community.
- Show empathy toward other community members.
