### PR TITLE
fix: only access propertiesSchema.properties once it's confirmed non-undefined

### DIFF
--- a/src/generators/ast.ts
+++ b/src/generators/ast.ts
@@ -105,12 +105,12 @@ export function getPropertiesSchema(event: Schema): ObjectTypeSchema {
     const propertiesSchema = event.properties.find(
       (schema: Schema): boolean => schema.name === 'properties',
     );
-    const isRequired = (propertiesSchema as ObjectTypeSchema).properties.find(
-      (schema: Schema): boolean => schema.isRequired === true,
-    );
     // The schema representing `.properties` in the RudderStack analytics
     // event should also always be an object.
     if (propertiesSchema && propertiesSchema.type === Type.OBJECT) {
+      const isRequired = (propertiesSchema as ObjectTypeSchema).properties.find(
+        (schema: Schema): boolean => schema.isRequired === true,
+      );
       properties = { ...propertiesSchema, isRequired: !!isRequired };
     }
   }


### PR DESCRIPTION
## Description 📝

![image](https://github.com/user-attachments/assets/1e66bb91-ceb8-4c0d-b6ce-4820b22c5666)

running with `--debug` gave
```
Trace: {
  isWrappedError: true,
  description: 'An unexpected error occurred.',
  notes: [ "Cannot read properties of undefined (reading 'properties')" ],
  error: TypeError: Cannot read properties of undefined (reading 'properties')
      at getPropertiesSchema (rudder-typer/src/generators/ast.js:45:45)
      at rudder-typer/src/generators/android/android.js:75:32
      at Generator.next (<anonymous>)
      at rudder-typer/src/generators/android/android.js:7:71
      at new Promise (<anonymous>)
      at __awaiter (rudder-typer/src/generators/android/android.js:3:12)
      at Object.generateTrackCall (rudder-typer/src/generators/android/android.js:74:77)
      at rudder-typer/src/generators/gen.js:236:37
      at Generator.next (<anonymous>)
      at fulfilled (rudder-typer/src/generators/gen.js:4:58)
}
    at ErrorBoundary.<anonymous> (rudder-typer/src/cli/commands/error.js:51:25)
    at Generator.next (<anonymous>)
    at rudder-typer/src/cli/commands/error.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (rudder-typer/src/cli/commands/error.js:3:12)
    at ErrorBoundary.reportError (rudder-typer/src/cli/commands/error.js:49:40)
    at ErrorBoundary.<anonymous> (rudder-typer/src/cli/commands/error.js:63:24)
    at Generator.next (<anonymous>)
    at rudder-typer/src/cli/commands/error.js:7:71
    at new Promise (<anonymous>)
```

Modifying the code to debug, it crashed when `event` was this:
```json
{
	"name": "identify",
	"type": 5,
	"properties": [
		{
			"name": "traits",
			"type": 5,
			"properties": [
				{
					"name": "value",
					"type": 4,
					"description": "...",
					"isRequired": true
				}
			]
		}
	],
	"description": "My custom identify"
}

```
in the plan.json this was represented by:
```json
{
	"rules": {
		"events": [
			{
				"description": "My custom identify",
				"eventType": "identify",
				"name": "",
				"rules": {
					"$defs": {
					},
					"$schema": "http://json-schema.org/draft-07/schema#",
					"description": "My custom identify",
					"properties": {
						"traits": {
							"additionalProperties": false,
							"properties": {
								"value": {
									"description": "...",
									"type": [
										"number"
									]
								}
							},
							"required": [
								"value"
							],
							"type": "object"
						}
					},
					"type": "object"
				}
			},
```

Please add tests for this case.