### PR TITLE
fix: make RudderTyperUtils.java compilable with -werror

### DIFF
--- a/src/generators/android/templates/RudderTyperUtils.java.hbs
+++ b/src/generators/android/templates/RudderTyperUtils.java.hbs
@@ -39,10 +39,10 @@ public final class RudderTyperUtils {
             return props;
         }
 
-        List p = new ArrayList<>();
+        List<Object> p = new ArrayList<>();
         for(Object item : props) {
             if (item instanceof List) {
-                p.add(serializeList((List) item));
+                p.add(serializeList((List<?>) item));
             } else if(item instanceof SerializableProperties) {
                 p.add(((SerializableProperties) item).toRudderProperty());
             } else {


### PR DESCRIPTION
## Description 📝

The generated code has problems with Java's built-in compiler checks when used with `-Werror`:
```
warning: [rawtypes] found raw type: List
warning: [unchecked] unchecked call to add(E) as a member of the raw type List
error: warnings found and -Werror specified
1 error
4 warnings
warnings found and -Werror specified
```

Fixing the `rawtypes` problems fixes the others.