### PR TITLE
fix: remove field name prefixes in generated code 

### DIFF
--- a/src/generators/android/android.ts
+++ b/src/generators/android/android.ts
@@ -94,7 +94,7 @@ export const android: Generator<
     let object: AndroidObjectContext | undefined;
 
     if (properties.length > 0) {
-      const className = client.namer.register(schema.name, 'class', {
+      const className = client.namer.register(schema.identifierName || schema.name, 'class', {
         transform: (name: string) => {
           return upperFirst(camelCase(name));
         },

--- a/src/generators/ast.ts
+++ b/src/generators/ast.ts
@@ -14,6 +14,9 @@ export type UnionTypeSchema = SchemaMetadata & UnionTypeFields;
 
 export type SchemaMetadata = {
   name: string;
+  // The language-appropriate identifier name for this property or type
+  // Used across different generators for class names, interface names, etc.
+  identifierName?: string;
   description?: string;
   isRequired?: boolean;
   isNullable?: boolean;

--- a/src/generators/gen.ts
+++ b/src/generators/gen.ts
@@ -356,7 +356,7 @@ async function runGenerator<
       }
 
       if (parentPath !== '') {
-        schema.name = eventName + upperFirst(schema.name);
+        schema.identifierName = eventName + upperFirst(schema.name);
       }
 
       const { property, object } = await generator.generateObject(

--- a/src/generators/javascript/javascript.ts
+++ b/src/generators/javascript/javascript.ts
@@ -136,9 +136,13 @@ export const javascript: Generator<
       };
     } else {
       // Otherwise generate an interface to represent this object.
-      const interfaceName = client.namer.register(schema.name, 'interface', {
-        transform: (name: string) => upperFirst(camelCase(name)),
-      });
+      const interfaceName = client.namer.register(
+        schema.identifierName || schema.name,
+        'interface',
+        {
+          transform: (name: string) => upperFirst(camelCase(name)),
+        },
+      );
       return {
         property: conditionallyNullable(schema, {
           name: client.namer.escapeString(schema.name),

--- a/src/generators/objc/objc.ts
+++ b/src/generators/objc/objc.ts
@@ -111,7 +111,7 @@ export const objc: Generator<
     if (properties.length > 0) {
       // If at least one property is set, generate a class that only allows the explicitly
       // allowed properties.
-      const className = client.namer.register(schema.name, 'class', {
+      const className = client.namer.register(schema.identifierName || schema.name, 'class', {
         transform: (name: string) => {
           return `RS${upperFirst(camelCase(name))}`;
         },

--- a/src/generators/swift/swift.ts
+++ b/src/generators/swift/swift.ts
@@ -122,7 +122,7 @@ export const swift: Generator<
     if (properties.length > 0) {
       // If at least one property is set, generate a class that only allows the explicitly
       // allowed properties.
-      const className = client.namer.register(schema.name, 'class', {
+      const className = client.namer.register(schema.identifierName || schema.name, 'class', {
         transform: (name: string) => {
           return `${upperFirst(camelCase(name))}`;
         },


### PR DESCRIPTION
# Thank You for Contributing to RudderTyper!

We sincerely appreciate the time and effort you invest in helping to improve RudderTyper. To make the most of your contribution, we kindly ask that you document your Pull Request thoroughly.

Please note that if the information provided is insufficient, or if the Pull Request does not align with our roadmap, we may need to respectfully thank you for your effort and close the issue.

## Description 📝

> This PR removes the prefix applied to field names in generated code while keeping type name prefixes for uniqueness.  

Context:
- Previously, field names were prefixed with their parent type name, which led to inconsistencies and redundancy.
- This update ensures cleaner and more consistent field naming while still maintaining uniqueness at the type level.

Changes  
- Removed automatic field name prefixing while preserving type name prefixes.

Impact  
- Generated code will now have cleaner field names without unnecessary prefixes.  
- Type uniqueness is still maintained through type name prefixes.  

## Respect Earns Respect 👏

We ask that you adhere to our [Code of Conduct](CODE_OF_CONDUCT.md). In summary:

- Use welcoming and inclusive language.
- Respect differing viewpoints and experiences.
- Accept constructive criticism gracefully.
- Focus on what is best for the community.
- Show empathy toward other community members.
