### PR TITLE
fix: sort choices by createdat during initialisation process

### DIFF
--- a/src/cli/api/api.ts
+++ b/src/cli/api/api.ts
@@ -215,7 +215,7 @@ export async function fetchTrackingPlans(options: {
     options.token,
     options.email,
   );
-  response.tracking_plans.map((tp) => ({
+  const v1Plans = response.tracking_plans.map((tp) => ({
     ...tp,
     createdAt: new Date(tp.create_time),
     updatedAt: new Date(tp.update_time),
@@ -226,13 +226,13 @@ export async function fetchTrackingPlans(options: {
     options.token,
     options.email,
   );
-  responseV2.trackingPlans.map((tp) => ({
+  const v2Plans = responseV2.trackingPlans.map((tp) => ({
     ...tp,
     createdAt: new Date(tp.createdAt),
     updatedAt: new Date(tp.updatedAt),
   }));
 
-  return response.tracking_plans.concat(responseV2.trackingPlans);
+  return [...v1Plans, ...v2Plans];
 }
 
 // fetchWorkspace lists the workspace found with a given Rudder API token.

--- a/src/cli/commands/init.tsx
+++ b/src/cli/commands/init.tsx
@@ -689,9 +689,8 @@ const TrackingPlanPrompt: React.FC<TrackingPlanPromptProps> = ({
       label: getTrackingPlanName(tp),
       value: getTrackingPlanName(tp),
     })),
-    'label',
-
-    'asc',
+    'createdAt',
+    'desc',
   );
   let initialIndex = choices.findIndex(
     (c) => !!trackingPlan && c.value === getTrackingPlanName(trackingPlan),


### PR DESCRIPTION
# Thank You for Contributing to RudderTyper!

We sincerely appreciate the time and effort you invest in helping to improve RudderTyper. To make the most of your contribution, we kindly ask that you document your Pull Request thoroughly.

Please note that if the information provided is insufficient, or if the Pull Request does not align with our roadmap, we may need to respectfully thank you for your effort and close the issue.

## Description 📝

> updates the initialization process to sort tp in descending order based on createdAt

## Respect Earns Respect 👏

We ask that you adhere to our [Code of Conduct](CODE_OF_CONDUCT.md). In summary:

- Use welcoming and inclusive language.
- Respect differing viewpoints and experiences.
- Accept constructive criticism gracefully.
- Focus on what is best for the community.
- Show empathy toward other community members.
