### PR TITLE
Fix ts2783 in generated file in TS

### DIFF
--- a/src/generators/javascript/templates/index.hbs
+++ b/src/generators/javascript/templates/index.hbs
@@ -729,7 +729,6 @@ export function {{functionName}}
 	callback?: apiCallback
 ): void {
 	const message = withRudderTyperContext({
-		groupId: '',
 		...groupMessage,
 	})
 	const a = analytics()


### PR DESCRIPTION
## Description 📝

Hello 👋
This PR aims to fix a TS error we're encountering in the generated code in TypeScript.
The error is the following:

```
... error TS2783: 'groupId' is specified more than once, so this usage will be overwritten.
```
Since in your `GroupMessage` type the `groupId` is mandatory, TS consider that it will always be overwritten.

Given what I see I thought that this line was unnecessary, but maybe my assumption is incorrect and the typing is wrong (in that case there probably is something else to do it, like make the `groupId` optional in the typing of the `GroupMessage`).

Thank you in advance for your review and the package itself 😄 