### PR TITLE
chore(ci): migrate from PAT to GitHub App token [SEC-58]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # GITHUB_TOKEN only needs read; App Token handles writes
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/hotfix/')
@@ -21,6 +21,15 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
 
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -38,18 +47,12 @@ jobs:
           HUSKY: 0
         run: npm run setup
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
         id: create-release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
@@ -72,6 +75,9 @@ jobs:
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
+
+          # Configure git to use App Token for push
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push --set-upstream origin "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
@@ -86,22 +92,31 @@ jobs:
           HUSKY: 0
         run: |
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
-          echo $SUMMARY
-          echo "::set-output name=commit_summary::$SUMMARY"
+          echo "$SUMMARY"
+          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           git fetch --no-tags --prune --depth=100 origin master
-          npm run release
+          npm run release -- --skip.commit --skip.tag
 
-      - name: Push new version in release branch
-        run: |
-          git push --follow-tags
+      - name: Create verified commit and tag via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            package.json
+            package-lock.json
+          tag: 'v${{ steps.create-release.outputs.new_version }}'
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master'
           pr_body: ':crown: *An automated PR*'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -74,11 +74,13 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
 
-          # Configure git to use App Token for push
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git push --set-upstream origin "$branch_name"
+          # Create branch via GitHub API instead of git push
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/$branch_name" \
+            -f sha="$BASE_SHA"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -14,6 +14,8 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # GITHUB_TOKEN only needs read; App Token handles writes
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
 
     steps:
@@ -21,6 +23,15 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create GitHub releases
+          permission-pull-requests: write # to create PRs
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -68,7 +79,7 @@ jobs:
         with:
           source_branch: 'master'
           destination_branch: 'develop'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}'
           pr_body: ':crown: *An automated PR*'
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -69,8 +69,7 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npm run release:github
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           branches: 'hotfix-release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Delete release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master
@@ -96,4 +96,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Migrates draft-new-release.yml and publish-new-release.yml from PAT to GitHub App Token
- Replaces `git push` with `ryancyq/github-signed-commit` for verified commits in draft-new-release.yml
- Adds explicit job-level permissions following security best practices
- Fixes deprecated `::set-output` workflow command
- Simplifies workflow by using GitHub API for branch creation (eliminates `git remote set-url` and `git push --set-upstream`)

### Migration Pattern Evolution
1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them
4. This approach is cleaner, more secure, and avoids embedding tokens in git remote URLs

### Migration Details
| File | Change | Why |
|------|--------|-----|
| draft-new-release.yml | PAT -> App Token, git push -> ryancyq/github-signed-commit, git push --set-upstream -> gh api | Verified commits require GitHub API; App Token ensures PRs trigger CI; API branch creation is cleaner |
| publish-new-release.yml | PAT -> App Token, added permissions block | App Token ensures PRs trigger CI; explicit permissions improves security |

### Changes in draft-new-release.yml
- Added GitHub App Token generation step early in the workflow
- Replaced `npm run release` with `npm run release -- --skip.commit --skip.tag` to generate files without committing
- Replaced `git remote set-url` and `git push --set-upstream` with `gh api repos/${{ github.repository }}/git/refs` for API-based branch creation
- Replaced `git push --follow-tags` with `ryancyq/github-signed-commit` action to create verified commits via GitHub API
- Replaced PAT with App Token for PR creation
- Updated deprecated `::set-output` to use `$GITHUB_OUTPUT`

### Changes in publish-new-release.yml
- Added GitHub App Token generation step
- Added explicit job-level permissions (`contents: read`)
- Replaced PAT with App Token for PR creation

## Test plan
- [ ] Verify draft-new-release workflow runs successfully and creates verified commits
- [ ] Verify publish-new-release workflow runs successfully after release PR is merged
- [ ] Verify created PRs trigger CI checks

Generated with [Claude Code](https://claude.com/claude-code)