### PR TITLE
feat(js/ts): add `enumStyle: union` option to emit string literal unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ client:
   # Valid values: 'CommonJS','AMD','UMD','System','ES2015','ESNext'
   moduleTarget: 'ESNext'
 
+  # How enum-constrained schemas are emitted in TS/JS output.
+  # Valid values: 'enum' (default), 'union'
+  #   'enum'  -> `export enum X { S_FOO = 'foo' }` (nominal type — required to use enum members at call sites)
+  #   'union' -> `export type X = 'foo' | 'bar'`   (string literal union — assignable from plain strings,
+  #              composes with consumer codebases whose enum-typed values are literal unions or
+  #              differently-named enums)
+  enumStyle: 'enum'
+
 trackingPlans:
   # The RudderStack Tracking Plan that you are generating a client for.
   # Provide your workspace slug and Tracking Plan id

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,12 @@ export default {
     ],
   },
   transformIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/reports/', '<rootDir>/node_modules/'],
+  // Allow tests to traverse source files that use ESM-style relative imports with
+  // explicit ".js" suffixes (e.g. `import './ast.js'`). ts-jest resolves these
+  // back to their TypeScript source by stripping the suffix.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   testMatch: [
     '<rootDir>/tests/**/*.(spec|test).(j|t)s?(x)',
     '<rootDir>/src/**/*.(spec|test).(j|t)s?(x)',

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -90,6 +90,7 @@ const ConfigSchema = Joi.object().required().keys({
         language: Joi.string().valid('javascript', 'typescript'),
         scriptTarget: Joi.string().optional().valid('ES3', 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ESNext', 'Latest'),
         moduleTarget: Joi.string().optional().valid('CommonJS', 'AMD', 'UMD', 'System', 'ES2015', 'ESNext'),
+        enumStyle: Joi.string().optional().valid('enum', 'union'),
       },
     })
     .when('sdk', {

--- a/src/generators/javascript/enums.ts
+++ b/src/generators/javascript/enums.ts
@@ -1,0 +1,55 @@
+import { sanitizeKey } from '../utils.js';
+
+// Builds the body of an `enum X { ... }` declaration, e.g.
+// "S_FOO = 'foo',\n    S_BAR = 'bar',".
+// Booleans/nulls are dropped because TS string/number enums only accept those
+// two literal types.
+export const convertToEnum = (values: any[], type: string): string => {
+  const unionTypes = [...new Set(type.split(' | '))];
+
+  return (
+    values
+      .map((value) => {
+        let key, formattedValue;
+
+        if (type === 'number' || (unionTypes.includes('number') && typeof value === 'number')) {
+          key = 'N_' + sanitizeKey(value);
+          formattedValue = `${value}`;
+        } else if (
+          type === 'string' ||
+          (unionTypes.includes('string') && typeof value === 'string')
+        ) {
+          key = 'S_' + sanitizeKey(value);
+          formattedValue = `'${value.toString().replace(/'/g, "\\'").trim()}'`;
+        }
+
+        return key && formattedValue ? `${key} = ${formattedValue}` : null;
+      })
+      .filter(Boolean)
+      .join(',\n    ') + ','
+  );
+};
+
+// Builds the body of a `type X = ...` declaration, e.g. "'foo' | 'bar'".
+// Booleans/nulls are dropped to mirror convertToEnum behaviour; extending this
+// to include them is straightforward (TS supports `true`/`false`/`null` literals)
+// and can be done in a follow-up.
+// Returns "never" when no values survive — produces a valid (uninhabited) type
+// rather than empty output that would fail to compile.
+export const convertToUnion = (values: any[], type: string): string => {
+  const unionTypes = [...new Set(type.split(' | '))];
+
+  const literals = values
+    .map((value) => {
+      if (type === 'number' || (unionTypes.includes('number') && typeof value === 'number')) {
+        return `${value}`;
+      }
+      if (type === 'string' || (unionTypes.includes('string') && typeof value === 'string')) {
+        return `'${value.toString().replace(/'/g, "\\'").trim()}'`;
+      }
+      return null;
+    })
+    .filter((v): v is string => v !== null);
+
+  return literals.length > 0 ? literals.join(' | ') : 'never';
+};

--- a/src/generators/javascript/javascript.ts
+++ b/src/generators/javascript/javascript.ts
@@ -6,7 +6,8 @@ import { Generator, GeneratorClient, type File } from '../gen.js';
 import { toTarget, toModule } from './targets.js';
 import { registerPartial } from '../../templates.js';
 import lodash from 'lodash';
-import { getEnumPropertyTypes, sanitizeEnumKey, sanitizeKey } from '../utils.js';
+import { getEnumPropertyTypes, sanitizeEnumKey } from '../utils.js';
+import { convertToEnum, convertToUnion } from './enums.js';
 
 const { camelCase, upperFirst } = lodash;
 
@@ -47,8 +48,14 @@ type JavaScriptPropertyContext = {
   hasEnum: boolean;
   // The formatted enum name
   enumName?: string;
-  // The formatted enum values
+  // The formatted enum values. For 'enum' style this is the body of an `enum {}`
+  // declaration (e.g. "S_FOO = 'foo',\n  S_BAR = 'bar',"). For 'union' style this
+  // is the body of a `type X = ...` declaration (e.g. "'foo' | 'bar'").
   enumValues?: any;
+  // True when the enum should be rendered as a string literal union (`type X = 'a' | 'b'`)
+  // instead of a nominal enum (`enum X { S_A = 'a', S_B = 'b' }`). Set from
+  // client.options.client.enumStyle.
+  isUnionEnum?: boolean;
   // The ref name of this property.
   _refName?: string;
 };
@@ -113,13 +120,14 @@ export const javascript: Generator<
       type = 'string';
       hasEnum = !!schema.enum;
       if (hasEnum) {
-        const { enumName, enumValues } = generateEnum(client, schema, {
+        const { enumName, enumValues, isUnionEnum } = generateEnum(client, schema, {
           name: client.namer.escapeString(schema.name),
           type,
         });
         overrides.push({
           enumName,
           enumValues,
+          isUnionEnum,
         });
       }
     } else if (schema.type === Type.BOOLEAN) {
@@ -128,13 +136,14 @@ export const javascript: Generator<
       type = 'number';
       hasEnum = !!schema.enum;
       if (hasEnum) {
-        const { enumName, enumValues } = generateEnum(client, schema, {
+        const { enumName, enumValues, isUnionEnum } = generateEnum(client, schema, {
           name: client.namer.escapeString(schema.name),
           type,
         });
         overrides.push({
           enumName,
           enumValues,
+          isUnionEnum,
         });
       }
     }
@@ -196,7 +205,7 @@ export const javascript: Generator<
     const overrides: Partial<JavaScriptPropertyContext>[] = [];
 
     if (hasEnum) {
-      const { enumName, enumValues } = generateEnum(client, schema, {
+      const { enumName, enumValues, isUnionEnum } = generateEnum(client, schema, {
         name: client.namer.escapeString(schema.name),
         type: types.map((t) => t.type).join(' | '),
       });
@@ -204,6 +213,7 @@ export const javascript: Generator<
       overrides.push({
         enumName,
         enumValues,
+        isUnionEnum,
       });
     }
     return conditionallyNullable(
@@ -266,39 +276,24 @@ export const javascript: Generator<
   },
 };
 
-const convertToEnum = (values: any[], type: string) => {
-  const unionTypes = [...new Set(type.split(' | '))];
-
-  return (
-    values
-      .map((value) => {
-        let key, formattedValue;
-
-        if (type === 'number' || (unionTypes.includes('number') && typeof value === 'number')) {
-          key = 'N_' + sanitizeKey(value);
-          formattedValue = `${value}`;
-        } else if (
-          type === 'string' ||
-          (unionTypes.includes('string') && typeof value === 'string')
-        ) {
-          key = 'S_' + sanitizeKey(value);
-          formattedValue = `'${value.toString().replace(/'/g, "\\'").trim()}'`;
-        }
-
-        return key && formattedValue ? `${key} = ${formattedValue}` : null;
-      })
-      .filter(Boolean)
-      .join(',\n    ') + ','
-  );
-};
-
 function generateEnum(
   client: GeneratorClient,
   schema: Schema,
   property: PropertyContext,
-): { enumName: string; enumValues: string | undefined } {
+): { enumName: string; enumValues: string | undefined; isUnionEnum: boolean } {
   let enumName = sanitizeEnumKey(schema.name) + '_' + getEnumPropertyTypes(schema);
-  const enumValues = 'enum' in schema ? convertToEnum(schema.enum!, property.type) : undefined;
+
+  const isUnionEnum =
+    (client.options.client.language === Language.JAVASCRIPT ||
+      client.options.client.language === Language.TYPESCRIPT) &&
+    (client.options.client as { enumStyle?: 'enum' | 'union' }).enumStyle === 'union';
+
+  const enumValues =
+    'enum' in schema
+      ? isUnionEnum
+        ? convertToUnion(schema.enum!, property.type)
+        : convertToEnum(schema.enum!, property.type)
+      : undefined;
 
   if (
     client.options.client.language === Language.JAVASCRIPT ||
@@ -318,6 +313,7 @@ function generateEnum(
   return {
     enumName,
     enumValues,
+    isUnionEnum,
   };
 }
 

--- a/src/generators/javascript/templates/index.hbs
+++ b/src/generators/javascript/templates/index.hbs
@@ -106,10 +106,14 @@ export interface Schema {
 {{#each properties}}
 {{#if hasEnum}}
 	{{#uniqueEnum enumName enumValues}}
+	{{#if isUnionEnum}}
+	export type {{enumName}} = {{enumValues}}
+	{{else}}
 	export enum {{enumName}} {
 	{{enumValues}}
 	}
-	
+	{{/if}}
+
 	{{/uniqueEnum}}
 {{/if}}
 {{/each}}
@@ -354,10 +358,14 @@ function withRudderTyperContext{{#unless isBrowser}}<P, T extends PayloadMessage
 {{#each defs}}
 {{#if hasEnum}}
 	{{#uniqueEnum enumName enumValues}}
+	{{#if isUnionEnum}}
+	export type {{enumName}} = {{enumValues}}
+	{{else}}
 	export enum {{enumName}} {
 	{{enumValues}}
 	}
-	
+	{{/if}}
+
 	{{/uniqueEnum}}
 {{/if}}
 {{/each}}

--- a/src/generators/javascript/templates/index.hbs
+++ b/src/generators/javascript/templates/index.hbs
@@ -105,7 +105,7 @@ export interface Schema {
 {{#each objects}}
 {{#each properties}}
 {{#if hasEnum}}
-	{{#uniqueEnum enumName enumValues}}
+	{{#uniqueEnum enumName enumValues isUnionEnum}}
 	{{#if isUnionEnum}}
 	export type {{enumName}} = {{enumValues}}
 	{{else}}
@@ -357,7 +357,7 @@ function withRudderTyperContext{{#unless isBrowser}}<P, T extends PayloadMessage
 
 {{#each defs}}
 {{#if hasEnum}}
-	{{#uniqueEnum enumName enumValues}}
+	{{#uniqueEnum enumName enumValues isUnionEnum}}
 	{{#if isUnionEnum}}
 	export type {{enumName}} = {{enumValues}}
 	{{else}}

--- a/src/generators/options.ts
+++ b/src/generators/options.ts
@@ -15,6 +15,8 @@ export enum Language {
   JAVA = 'java',
 }
 
+export type EnumStyle = 'enum' | 'union';
+
 export type TypeScriptOptions = {
   sdk: SDK.WEB | SDK.NODE;
   language: Language.TYPESCRIPT;
@@ -22,6 +24,12 @@ export type TypeScriptOptions = {
   // present on the tracking plan
   defSupport: true;
   uniqueEnums?: boolean;
+  // Output style for enum-constrained schemas. Defaults to 'enum'.
+  //   'enum'  → emits `export enum X { S_FOO = 'foo', S_BAR = 'bar' }` (nominal type)
+  //   'union' → emits `export type X = 'foo' | 'bar'` (string literal union, structurally
+  //             assignable from plain string literals — pairs well with consumers whose
+  //             source values are typed as literal unions or differently-named enums.)
+  enumStyle?: EnumStyle;
 };
 
 export type JavaScriptOptions = {
@@ -42,6 +50,9 @@ export type JavaScriptOptions = {
   // defSupport is true for Javascript as well
   defSupport: true;
   uniqueEnums?: boolean;
+  // See TypeScriptOptions.enumStyle. JavaScript output is transpiled from TypeScript;
+  // when 'union' is set the union-typed declaration is erased and only runtime values remain.
+  enumStyle?: EnumStyle;
 };
 
 export type ObjectiveCOptions = {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -85,10 +85,18 @@ export async function registerStandardHelpers(): Promise<void> {
   });
 
   const processedEnums = new Set();
-  Handlebars.registerHelper('uniqueEnum', function (enumName, enumValues, options) {
+  Handlebars.registerHelper('uniqueEnum', function (enumName, enumValues, isUnionEnum, options) {
+    // Handlebars passes the block's `options` as the last positional arg regardless
+    // of how many args were declared at the call site. When callers write
+    // `{{#uniqueEnum enumName enumValues}}` (two args), `isUnionEnum` is actually
+    // the options object and the real options is undefined — detect and shift.
+    if (options === undefined) {
+      options = isUnionEnum;
+      isUnionEnum = undefined;
+    }
     if (!processedEnums.has(enumName)) {
       processedEnums.add(enumName);
-      return options.fn({ enumName, enumValues });
+      return options.fn({ enumName, enumValues, isUnionEnum });
     }
     return '';
   });

--- a/tests/javascript-enum-style.test.ts
+++ b/tests/javascript-enum-style.test.ts
@@ -1,0 +1,51 @@
+import { convertToEnum, convertToUnion } from '../src/generators/javascript/enums';
+
+describe('convertToUnion (enumStyle: "union")', () => {
+  test('emits string literal union for plain string enum', () => {
+    expect(convertToUnion(['happy', 'sad', 'meh'], 'string')).toBe("'happy' | 'sad' | 'meh'");
+  });
+
+  test('emits number literal union for plain number enum', () => {
+    expect(convertToUnion([200, 404, 500], 'number')).toBe('200 | 404 | 500');
+  });
+
+  test('escapes single quotes inside string literals', () => {
+    expect(convertToUnion(["it's", 'plain'], 'string')).toBe("'it\\'s' | 'plain'");
+  });
+
+  test('handles mixed string|number union types', () => {
+    expect(convertToUnion(['yes', 1, 'no', 2], 'string | number')).toBe("'yes' | 1 | 'no' | 2");
+  });
+
+  test('drops booleans (parity with convertToEnum which does the same)', () => {
+    expect(convertToUnion(['yes', 'no', true, false], 'string | boolean')).toBe("'yes' | 'no'");
+  });
+
+  test('returns "never" when no values survive (e.g. all booleans)', () => {
+    expect(convertToUnion([true, false], 'boolean')).toBe('never');
+  });
+
+  test('trims whitespace inside string literals', () => {
+    expect(convertToUnion(['  spaced  ', 'tight'], 'string')).toBe("'spaced' | 'tight'");
+  });
+
+  test('returns "never" for empty enum', () => {
+    expect(convertToUnion([], 'string')).toBe('never');
+  });
+});
+
+describe('convertToEnum (default style — backward compatibility)', () => {
+  test('emits string-keyed enum body for plain string enum', () => {
+    expect(convertToEnum(['happy', 'sad'], 'string')).toBe(
+      "S_HAPPY = 'happy',\n    S_SAD = 'sad',",
+    );
+  });
+
+  test('emits number-keyed enum body for plain number enum', () => {
+    expect(convertToEnum([200, 404], 'number')).toBe('N_200 = 200,\n    N_404 = 404,');
+  });
+
+  test('drops booleans (preserves pre-PR behaviour)', () => {
+    expect(convertToEnum(['yes', true], 'string | boolean')).toBe("S_YES = 'yes',");
+  });
+});


### PR DESCRIPTION
## Summary

Today rudder-typer generates TypeScript string enums for enum-constrained schemas (`export enum Mood_String { S_HAPPY = 'happy' }`). Because TS enums are nominally typed, plain string literals — and consumer enums with the same values — are not directly assignable to the generated type. **Adopting rudder-typer in a real codebase requires writing adapter functions for every custom enum at every call site to bridge the nominal/structural gap.** I'd be surprised if many production codebases are using rudder-typer's enums directly today without that workaround layer.

Switching from nominal enums to string literal unions isn't a big lift, and it eliminates the friction entirely. This PR adds an opt-in `enumStyle: 'union'` option that emits literal unions instead:

```ts
// Before (default, unchanged)
export enum Mood_String {
  S_HAPPY = 'happy',
  S_SAD = 'sad',
}

// After (with `enumStyle: 'union'`)
export type Mood_String = 'happy' | 'sad'
```

Literal unions are structurally typed: any source whose values overlap the union — including consumer enums with matching string values — assigns without casts or adapters.

## Behaviour

- **Default (`enumStyle` omitted, or `enumStyle: 'enum'`)**: no change. Existing consumers keep emitting `export enum X {}` declarations.
- **`enumStyle: 'union'` (opt-in)**: emits `export type X = 'a' | 'b'`. Numeric enums become number literal unions (`200 | 404 | 500`). All-boolean enums (which never produced output before) become `never`.

Backwards compatibility is preserved end-to-end; the new behaviour is opt-in via `client.enumStyle` in `ruddertyper.yml`.

## Implementation

- New `src/generators/javascript/enums.ts` housing both `convertToEnum` (extracted unchanged from `javascript.ts`) and the new `convertToUnion`. Pure functions, no template/template-loader dependency — keeps them cheap to unit-test.
- `JavaScriptPropertyContext` gains an `isUnionEnum?: boolean` flag, threaded through the three `generateEnum` call sites in `javascript.ts`.
- `templates/index.hbs` branches on `isUnionEnum` in the two enum emission blocks (per-property and per-def). Same dedup logic via `uniqueEnum` helper.
- `TypeScriptOptions` and `JavaScriptOptions` (in `src/generators/options.ts`) gain `enumStyle?: EnumStyle` where `EnumStyle = 'enum' | 'union'`.
- Joi schema (`src/cli/config/schema.ts`) accepts the option as part of the JS/TS validation branch.
- README documents the option alongside `scriptTarget`/`moduleTarget`.

## Tests

11 new unit tests in `tests/javascript-enum-style.test.ts` covering `convertToUnion` (8 cases) and `convertToEnum` (3 cases — to lock the backward-compatible default in place):

- string / number / mixed-type enum literal output
- single-quote escaping
- whitespace trimming inside literals
- boolean drop behaviour (parity with the existing converter)
- empty input → `never` (a valid uninhabited type)
- backward-compat coverage of the existing string/number enum body output

Required a small `jest.config.js` `moduleNameMapper` tweak to let test files traverse source files that use ESM-style relative imports with explicit `.js` suffixes — needed only because `tests/` previously didn't import anything that hit those.

All 28 tests pass; lint clean; build clean.

## Risk / Impact

- **Low.** Default behaviour is unchanged; the option is opt-in.
- The `convertToEnum` extraction to `enums.ts` is byte-for-byte identical to its previous inline version (covered by the new backward-compat tests).
- The template change adds an `{{#if isUnionEnum}}` branch around the existing `export enum` block; the `else` branch is the original output verbatim.

## Checklist

- [x] Lint clean
- [x] Build clean
- [x] 28/28 tests pass (17 existing + 11 new)
- [x] README updated with the new option
- [x] Backward compatible (default = `'enum'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)